### PR TITLE
feat: add Netlify credit in footer for open source organization

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -38,6 +38,7 @@
     </div>
     <div class="{{ site.data.grid.classes[2] }} mt-5">
       <a href="/mentions-legales">Mentions légales</a><br>
+      <a href="https://www.netlify.com" target="_blank" rel="noreferrer">This site is powered by Netlify</a><br>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
# TLDR
On a besoin de créditer Netlify sur le site mmibordeaux.com pour avoir une Team Open Source gratuite, voici une PR pour le faire.

# Contexte 
Avec @alexisben nous cherchons à créer une organisation Open-source sur Netlify pour héberger gratuitement les projets à but éducatif des promos MMI (sites de gros projets commun surtout). Actuellement, des projets parfois à long terme sont hébergé sur les comptes perso des étudiants : c'est problématique lorsqu'ils quittent la formation, ainsi que pour les coût que cela peut engendrer.


# Problème 
Alexis a envoyé une demande de Team Open Source via le formulaire https://opensource-form.netlify.com/
Netlify a décliné la demande sans spécifier pourquoi, ils ont seulement remis le lien vers la politique des Team Open Source : https://www.netlify.com/legal/open-source-policy/

# Proposition
Après la lecture de cette politique il me semble que le seul critère auquel ne répond pas la demande est le crédit à Netlify sur le site mmibordeaux.com
Je propose un lien simple plutôt que leur énorme badge :
<img width="1230" alt="Capture d’écran 2024-02-05 à 22 41 21" src="https://github.com/mmibordeaux/mmibordeaux.com/assets/28672596/a6a03fc2-f5d6-4e43-a4fb-0c52c202f1fc">

